### PR TITLE
Stricter Linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
 [MASTER]
-disable=fixme,too-few-public-methods,too-many-instance-attributes,too-many-arguments,logging-fstring-interpolation,too-many-locals,duplicate-code,    def buy_amount(self) -> Decimal:
+disable=fixme,logging-fstring-interpolation,too-many-arguments
 
 extension-pkg-allow-list=pydantic

--- a/src/models/order.py
+++ b/src/models/order.py
@@ -11,7 +11,10 @@ from typing import Optional, Any, Union
 from src.models.exchange_rate import ExchangeRate as XRate
 from src.models.token import Token, TokenBalance
 from src.models.types import NumericType
-from src.util.constants import Constants
+from src.util.constants import (
+    RAISE_ON_MAX_SELL_AMOUNT_VIOLATION,
+    RAISE_ON_LIMIT_XRATE_VIOLATION,
+)
 from src.util.numbers import decimal_to_str
 
 OrderSerializedType = dict[str, Any]
@@ -38,6 +41,8 @@ class Order:
     the order represents a classical limit {buy|sell} order,
     a cost-bounded {buy|sell} order or a {buy|sell} market order.
     """
+
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
@@ -303,7 +308,7 @@ class Order:
                     f"sell (max)  : {ymax.balance}"
                 )
                 logging.error(message)
-                if Constants.RAISE_ON_MAX_SELL_AMOUNT_VIOLATION:
+                if RAISE_ON_MAX_SELL_AMOUNT_VIOLATION:
                     raise ValueError(message)
             sell_amount = min(sell_amount, ymax)
 
@@ -330,7 +335,7 @@ class Order:
                     f"limit (max): {self.max_limit}"
                 )
                 logging.error(message)
-                if Constants.RAISE_ON_LIMIT_XRATE_VIOLATION:
+                if RAISE_ON_LIMIT_XRATE_VIOLATION:
                     raise ValueError(message)
 
         # Store execution information.

--- a/src/models/solver_args.py
+++ b/src/models/solver_args.py
@@ -13,6 +13,8 @@ from src.util.schema import MetadataModel
 class SolverArgs:
     """Parameters passed in POST URL"""
 
+    # pylint: disable=too-many-instance-attributes
+
     auction_id: Optional[str]
     instance_name: str
     time_limit: int

--- a/src/models/token.py
+++ b/src/models/token.py
@@ -6,7 +6,7 @@ from decimal import Decimal, getcontext
 from typing import Optional, Union
 
 from src.models.types import NumericType
-from src.util.constants import Constants
+from src.util.constants import DECIMAL_STR_PREC
 
 
 class Token:
@@ -101,7 +101,7 @@ class TokenInfo:
                 "external_price",
                 "internal_buffer",
             ]:
-                value = value.quantize(Constants.DECIMAL_STR_PREC)
+                value = value.quantize(DECIMAL_STR_PREC)
             _str += f"\n-- {attr} : {value}"
 
         return _str

--- a/src/models/uniswap.py
+++ b/src/models/uniswap.py
@@ -24,6 +24,8 @@ class Uniswap:
     An Uniswap pool is represented by two token balances.
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(
         self,
         pool_id: str,

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -2,17 +2,13 @@
 
 from decimal import Decimal
 
+# Precision of Decimal in strings (to be used as x.quantize(DECIMAL_STR_PREC)).
+DECIMAL_STR_PREC = Decimal("1e-10")
 
-class Constants:
-    """Configuration parameters for the solver."""
+# Should an exception be raised when the solution violates the
+# max sell amount constraint.
+RAISE_ON_MAX_SELL_AMOUNT_VIOLATION = False
 
-    # Precision of Decimal in strings (to be used as x.quantize(DECIMAL_STR_PREC)).
-    DECIMAL_STR_PREC = Decimal("1e-10")
-
-    # Should an exception be raised when the solution violates the
-    # max sell amount constraint.
-    RAISE_ON_MAX_SELL_AMOUNT_VIOLATION = False
-
-    # Should an exception be raised when the solution violates the
-    # limit exchange rate constraint.
-    RAISE_ON_LIMIT_XRATE_VIOLATION = False
+# Should an exception be raised when the solution violates the
+# limit exchange rate constraint.
+RAISE_ON_LIMIT_XRATE_VIOLATION = False

--- a/src/util/exec_plan_coords.py
+++ b/src/util/exec_plan_coords.py
@@ -2,12 +2,14 @@
 
 
 class ExecPlanCoords:
-    """The position coordinates of the uniswap in the execution plan.
+    """The position coordinates of the AMM in the execution plan.
 
     The position is defined by a pair of integers:
         * Id of the sequence.
         * Position within that sequence.
     """
+
+    # pylint: disable=too-few-public-methods
 
     def __init__(self, sequence: int, position: int):
         self.sequence = sequence

--- a/src/util/schema.py
+++ b/src/util/schema.py
@@ -251,6 +251,7 @@ class OrderModel(BaseModel):
     class Config:
         """Includes example in generated openapi file"""
 
+        # pylint: disable=too-few-public-methods
         schema_extra = {
             "example": {
                 "sell_token": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -326,6 +327,7 @@ class BatchAuctionModel(BaseModel):
     class Config:
         """Includes example in generated openapi file"""
 
+        # pylint: disable=too-few-public-methods
         schema_extra = {"example": example_instance}
 
 


### PR DESCRIPTION
remove exceptions from pylintrc. In some places we have to disable a few things locally. But I still think this is better than globally allowing such exceptions.