### PR TITLE
Manually parse JSON input

### DIFF
--- a/src/_server.py
+++ b/src/_server.py
@@ -54,9 +54,12 @@ def health() -> bool:
 
 
 @app.post("/solve", response_model=SettledBatchAuctionModel)
-async def solve(problem: BatchAuctionModel, request: Request):  # type: ignore
+async def solve(request: Request):  # type: ignore
     """API POST solve endpoint handler"""
-    logging.debug(f"Received solve request {await request.json()}")
+    body = await request.json()
+    logging.debug(f"Received solve request {body}")
+
+    problem = BatchAuctionModel(**body)
     solver_args = SolverArgs.from_request(request=request, meta=problem.metadata)
 
     batch = BatchAuction.from_dict(problem.dict(), solver_args.instance_name)


### PR DESCRIPTION
It looks like the driver is not setting reasonable `content-type` headers for requests to external solvers. This leads to issues with `fastapi` which doesn't "parse" (not sure if this is the correct term) the JSON body into the `BatchAuctionModel` class.

To work around this, manually parse the JSON into a batch auction model.

This PR is currently a draft as I'm exploring other options to make this work.