### PR TITLE
Update Gnosis RPC Endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 COW_DEX_AG_SOLVER_URL=http://host.docker.internal:8000
 ORDERBOOK_URL=https://protocol-xdai.dev.gnosisdev.com
 BASE_TOKENS=0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83
-NODE_URL=https://rpc.xdaichain.com
+NODE_URL=https://rpc.gnosischain.com
 SOLVER_ACCOUNT=0x7942a2b3540d1ec40b2740896f87aecb2a588731
 SOLVERS=CowDexAg
 TRANSACTION_STRATEGY=DryRun

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the [How to Write a Solver Tutorial](https://docs.cow.fi/tutorials/how-to-write-
 docker run -it --rm --add-host host.docker.internal:host-gateway ghcr.io/cowprotocol/services solver \
 --orderbook-url https://barn.api.cow.fi/xdai/api \
 --base-tokens 0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83 \
---node-url "https://rpc.xdaichain.com" \
+--node-url "https://rpc.gnosischain.com" \
 --cow-dex-ag-solver-url "http://127.0.0.1:8000" \
 --solver-account 0x7942a2b3540d1ec40b2740896f87aecb2a588731 \
 --solvers CowDexAg \
@@ -86,7 +86,7 @@ git clone https://github.com/cowprotocol/services.git
 cargo run -p solver -- \
     --orderbook-url https://barn.api.cow.fi/xdai/api \
     --base-tokens 0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83 \
-    --node-url "https://rpc.xdaichain.com" \
+    --node-url "https://rpc.gnosischain.com" \
     --cow-dex-ag-solver-url "http://127.0.0.1:8000" \
     --solver-account 0x7942a2b3540d1ec40b2740896f87aecb2a588731 \
     --solvers CowDexAg \


### PR DESCRIPTION
Changing 

```
NODE_URL=https://rpc.xdaichain.com
```
to
```
NODE_URL=https://rpc.gnosischain.com
```

Still waiting on backend to answer questions regarding other endpoint urls with xdai in them:

[slack](https://cowservices.slack.com/archives/C0375NV72SC/p1655321446461049)

Specifically to answer the following 

## Question

what will be the replacement for urls like this:

https://barn.api.cow.fi/xdai/api

and this

https://protocol-xdai.dev.gnosisdev.com

Has it already been changed?

Similarly, in auction instances, will the xdai in metadata be changed or has it already?
```
  "metadata": {
    "environment": "xDAI",
    "auction_id": 20,
    "gas_price": 4850000000.0,
    "native_token": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
  }
```

cc @nlordell 
