### PR TITLE
Add solving functionality: Match single order against a single Univ2

### DIFF
--- a/src/_server.py
+++ b/src/_server.py
@@ -73,8 +73,8 @@ async def solve(problem: BatchAuctionModel, request: Request):  # type: ignore
     print("Received Batch Auction", batch.name)
     print("Parameters Supplied", solver_args)
 
-    # 1. Solve BatchAuction: update batch_auction with
-    # batch.solve()
+    batch.solve()
+    return batch.output
 
     trivial_solution = {
         "orders": {},

--- a/src/_server.py
+++ b/src/_server.py
@@ -74,20 +74,8 @@ async def solve(problem: BatchAuctionModel, request: Request):  # type: ignore
     print("Parameters Supplied", solver_args)
 
     batch.solve()
+    print("\n\n*************\n\nReturning solution: " + str(batch.output))
     return batch.output
-
-    trivial_solution = {
-        "orders": {},
-        "foreign_liquidity_orders": [],
-        "amms": {},
-        "prices": {},
-        "approvals": [],
-        "interaction_data": [],
-        "score": "0",
-    }
-
-    print("\n\n*************\n\nReturning solution: " + str(trivial_solution))
-    return trivial_solution
 
 
 # ++++ Server setup: ++++

--- a/src/models/batch_auction.py
+++ b/src/models/batch_auction.py
@@ -218,6 +218,20 @@ class BatchAuction:
                         order.exec_buy_amount
                     ),  # (self.exec_buy_amount.as_decimal())
                 }
+                amm_dictionary = {
+                    "kind": "ConstantProduct",
+                    "execution" : [{
+                        "exec_sell_amount": decimal_to_str(order.buy_amount),
+                        "exec_buy_amount": decimal_to_str(order.sell_amount),
+                        "buy_token": str(order.sell_token),
+                        "sell_token": str(order.buy_token),
+                        "exec_plan": {
+                            "sequence": 0,
+                            "position": 0,
+                            "internal": False
+                        }
+                    }]
+                }
 
                 if order.fee is not None:
                     order_dictionary["fee"] = {
@@ -232,13 +246,15 @@ class BatchAuction:
                     }
 
                 self.output = {
-                    "ref_token": str(order.sell_token),
                     "orders": {str(order.order_id): order_dictionary},
+                    "foreign_liquidity_orders": [],
                     "prices": {
                         str(order.sell_token): 1000000000000000000,
                         str(order.buy_token): buy_price,
                     },
-                    "amms": {},
+                    "amms": {str(uniswap.pool_id): amm_dictionary},
+                    "approvals": [],
+                    "interaction_data": [],
                 }
                 return
 


### PR DESCRIPTION
This PR adds some very minimal solving functionality.

Specifically, it attempts to match a market sell order against a single Univ2. For that, it iterates over all market sell orders, and in case it successfully matches one such order, it immediately returns.