### PR TITLE
Use python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:alpine
+FROM python:3.10-alpine
+
 RUN apk add --update gcc libc-dev linux-headers
 
 WORKDIR /app
 
-# Only copies requirements.txt and src directory (see .dockerignore)
-COPY . .
+# First copy over the requirements.txt and install dependencies, this makes
+# building subsequent images easier.
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-ENTRYPOINT [ "python3", "-m" , "src._server"]
+# Copy full source (see .dockerignore)
+COPY . .
+
+CMD [ "python3", "-m" , "src._server"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone git@github.com:cowprotocol/solver-template-py.git
 2. Rust v1.60.0 or Docker
 
 ```sh
-python3 -m venv venv
+python3.10 -m venv venv
 source ./venv/bin/activate
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Some of the dependencies only work with Python 3.10 at the moment. The readme and docker file were changed to use this version.